### PR TITLE
Fixes incorrect email redirect

### DIFF
--- a/layouts/resume/resume.html
+++ b/layouts/resume/resume.html
@@ -15,7 +15,7 @@
 <body>
     <div id="hero" class="wrap">
     <h1 class = "text-center">Benjamin Hill</h1>
-    <h4 class = "text-center" ><a class="button outline"  href = "mailto: BenjaminHillCS@gmail.com" >Email</a> <a class="button outline" target="_blank" href="https://github.com/Benjamin00/" onclick="_gaq.push(['_trackEvent', 'kube', 'github']);">GitHub</a>
+    <h4 class = "text-center" ><a class="button outline"  href = "mailto:BenjaminHillCS@gmail.com" >Email</a> <a class="button outline" target="_blank" href="https://github.com/Benjamin00/" onclick="_gaq.push(['_trackEvent', 'kube', 'github']);">GitHub</a>
         <a class = "button outline" target="_blank" href = "https://www.linkedin.com/in/benjaminjhill/">LinkedIn</a></h4> 
     </div>
     <div id="kube-faq2">


### PR DESCRIPTION
Having a space after mailto adds %20 to beginning of email address. So anyone who will click on email their mail will actually get sent to %20BenjaminHillCS@gmail.com which is an invalid email address